### PR TITLE
[iOS] Add static framework

### DIFF
--- a/ios/midtrans_sdk.podspec
+++ b/ios/midtrans_sdk.podspec
@@ -21,6 +21,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
   s.platform = :ios, '8.0'
   s.ios.dependency 'MidtransKit', '1.18.2'
+  s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
Add static framework to fix error

> The 'Pods-Runner' target has transitive dependencies that include statically linked binaries: (MidtransKit and MidtransCoreKit)

Flutter version: 2.2.0